### PR TITLE
Update README to include Proguard instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,19 @@ You can also __fastBlur__ a `View`. This optimizes the view blurring process by 
 BlurKit.getInstance().fastBlur(View src, int radius, float downscaleFactor);
 ```
 
+## Proguard
+If you use Proguard, add the following to your proguard-rules.pro:
+
+```
+-keep class com.wonderkiln.blurkit.** { *; }
+
+-dontwarn android.support.v8.renderscript.*
+-keepclassmembers class android.support.v8.renderscript.RenderScript {
+  native *** rsn*(...);
+  native *** n*(...);
+}
+```
+
 ## To Do (incoming!)
 - [ ] `SurfaceView` support
 - [ ] Support for use outside of an `Activity` (dialogs, etc.)


### PR DESCRIPTION
Fixes: https://github.com/flurgle/BlurKit-Android/issues/19.  

When using Proguard without any proguard rules, I was getting a crash, `java.lang.NoSuchMethodError: no static or non-static method "Landroid/support/v8/renderscript/RenderScript;.nDeviceDestroy(J)V"`.  I've updated the README with the Proguard rules that fix the issue.  